### PR TITLE
README: Add clear instructions on how to test each agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,17 @@ It might take a few seconds to establish a connection.
 
 *(Remember this is a prototype system and it is still work-in-progress, so you might find bugs)*
 
-Once you loaded the frontend in your browser, you can load the included example to draft a manuscript from scratch:
+Once you accessed the frontend in your browser, you can load the included example to draft a manuscript from scratch:
 
 1. Click on the lightbulb icon ("Try an example") on the top right to load the guidelines (a set of bullet points per section) to draft [this peer-reviewed article](https://doi.org/10.1016/j.cels.2024.08.005).
-1. To *draft* sections of the manuscript, you need to select the _entire section_ and then click on the "Draft" action (see animation below).
-   The text you selected will be replaced by the draft when it's ready.
-1. If you are not happy with the current draft, you can *edit* the current draft by adding comments in the middle of it (such as `* emphasize more on this aspect`), selecting the entire section, and clicking on "Draft" again.
-1. You can upload figures before drafting a section, or after (in this case, you'll need to *edit* that section).
+   You'll see that the example contains a few bullet points per section.
+   These are the brief guidelines provided by human authors.
+1. To *draft* sections of the manuscript, you need to select the _entire section_ content and then click on the "Draft" action (see animation below).
+   When ready, the text you selected will be replaced by the draft.
+1. If you are not happy with the current draft, you can *edit* the current draft by adding comments in the middle of it (such as bullet points before a paragraph or notes in the middle of the text), selecting the entire section, and clicking on "Draft" again.
+1. You can upload figures before drafting a section by clicking on the paperclip icon on the top right corner.
    If your text/guidance for the Results section references your figures (such as "Figure 1"), and you uploaded that figure, the agent responsible for drafting the Results section will have access to the figure's description, which will be more helpful to generate the draft.
+   If you upload a figure after drafting the Results section, you can *edit* that section to incorporate the figure.
 
 <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
 

--- a/README.md
+++ b/README.md
@@ -129,25 +129,33 @@ It might take a few seconds to establish a connection.
 
 *(Remember this is a prototype system and it is still work-in-progress, so you might find bugs)*
 
-Once you accessed the frontend in your browser, you can load the included example to draft a manuscript from scratch:
+After opening the web interface in your browser, follow these steps to draft a manuscript from scratch:
 
-1. **Load an example of human guidelines:** click on the lightbulb icon ("Try an example") on the top right to load an example.
-   This example represents some ideas that a human author might quickly sketch when thinking in a future scientific manuscript.
-   These ideas might be a set of bullet points per section with early notes on how you are thinking about the structure, content, etc.
-   We call this the "human guidelines" for Manugen-AI.
-   The example corresponds to the guidelines for [this peer-reviewed article](https://doi.org/10.1016/j.cels.2024.08.005).
-   You'll see the example is written in Markdown, with some ideas for the different sections (abstract, results, etc).
-   This is what the most early version of your manuscript might look like, and will surely evolve with time.
-1. **Draft a section:** to *draft* sections of the manuscript, you need to select the _entire section_ content and then click on the "Draft" action (see animation below).
-   You can try with the entire Results section (which includes two subsections).
-   When ready, the text you selected will be replaced by the draft.
-1. **Edit an existing draft:** if you are not happy with the current draft, you can *edit* it by adding comments/instructions in the middle (such as bullet points before a paragraph or notes in the middle of the text with instructions for Manugen-AI), selecting the entire section, and clicking on "Draft" again.
-1. **Upload figures:** you can upload figures by clicking on the paperclip icon on the top right corner.
-   Once you upload a figure, Manugen-AI will interpret it by generating a title and a description that will be added to the internal state of the system, and used by the Results Agent when drafting this section.
-   When you drafted the Results section in the steps above (which had references to "Figure 1", "Figure 2" and "Figure 3"), the system didn't have any figures added yet, so the agent did its best with the content you provided in the bullet points.
-   Now, try to upload [Figures 1, 2 and 3 from this folder](frontend/public/example), and then *edit* the Results section (just select its text and click on the "Draft" action), and you'll see how its text now correctly references the actual content of the figures.
+1. **Load an example of human guidelines.**
+   Click the lightbulb icon ("Try an example") in the top right.
+   This loads a set of bullet‑point notes—our "human guidelines"—that sketch out what a future scientific manuscript might include (e.g., section headings, key ideas, structural notes).
+   This built‑in example corresponds to the guidelines for [this peer‑reviewed article](https://doi.org/10.1016/j.cels.2024.08.005) and is written in Markdown.
+   Treat this as the earliest draft of your manuscript, which will evolve over time.
 
-<img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
+1. **Draft a section.**
+   Select the *entire* content of the section you'd like to draft (for instance, the *Results* section, including its subsections), then click the *Draft* button.
+   Manugen‑AI will replace your selected text with a full draft generated from your guidelines.
+
+1. **Edit an existing draft.**
+   If the draft isn't quite right, add inline comments or extra bullet‑point notes—inserted anywhere within the section—to guide Manugen‑AI's revisions.
+   Reselect the entire section and click *Draft* again.
+   The system will incorporate your new instructions into the updated draft.
+
+1. **Upload and integrate figures.**
+   Click the paperclip icon in the top right to upload figures.
+   Once uploaded, Manugen‑AI analyzes each image and generates a title and description, storing this information for use in drafts.
+   If you've already drafted the Results section (which in the example references "Figure 1", "Figure 2", and "Figure 3") before uploading images, the system will have guessed their content.
+   To see accurate figure references, upload \[Figures 1–3 from the `frontend/public/example` folder\], then re‑draft the Results section (select its text and click *Draft*).
+   You'll now see the narrative updated to reflect each figure's actual content.
+
+<p align="left">
+  <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Drafting a manuscript section" width="90%" />
+</p>
 
 ### Enhance existing content with revision
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,6 @@ Our experienced team of engineers intends to turn this proof-of-concept into a f
 - 🔖 Read our [story on
   Medium](https://medium.com/@miltondp/manugen-ai-automatic-scientific-article-drafting-from-assets-and-guidance-47198ab0f244)
 
-## Project Structure
-
-The project is a standard three-tier web application, with the following components:
-
-- `./frontend/`: A web-based user interface for interacting with the application, built with React.
-- `./backend/`: A REST API that serves the frontend and handles requests from the web interface.
-- `./packages/manugen-ai/`: The *Manugen AI* package, which is used to generate academic manuscripts from content files.
-  The backend relies on this package to perform the actual manuscript generation.
-
-The project includes an optional PostgreSQL database that, if available, ADK will use to persist session data between stack runs.
-
 ## Installation
 
 ### Docker and Docker Compose
@@ -118,14 +107,14 @@ Pressing `Ctrl+C` will stop the application.
 
 Wait until you see a message resembling the following in the logs:
 
-### Accessing the Frontend
-
 ```
 VITE v6.3.5  ready in 1276 ms
 
 ➜  Local:   http://localhost:5173/
 ➜  Network: http://172.22.0.2:5173/
 ```
+
+### Accessing the Frontend
 
 Use a web browser to open http://localhost:8901 and to view the frontend user interface.
 It might take a few seconds to establish a connection.
@@ -191,6 +180,75 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
 ```
 
 ## Other Resources
+
+### Project Structure
+
+The project is a standard three-tier web application, with the following components:
+
+- `./frontend/`: A web-based user interface for interacting with the application, built with React.
+- `./backend/`: A REST API that serves the frontend and handles requests from the web interface.
+- `./packages/manugen-ai/`: The *Manugen AI* package, which is used to generate academic manuscripts from content files.
+  The backend relies on this package to perform the actual manuscript generation.
+
+The project includes an optional PostgreSQL database that, if available, ADK will use to persist session data between stack runs.
+
+### Accessing the Backend API
+
+While it's not necessary to use the app, you might want to access the backend API directly for testing or debugging purposes.
+
+Wait until you see the following message in the logs:
+
+```
+INFO:     Will watch for changes in these directories: ['/app']
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [102] using WatchFiles
+INFO:     Started server process [104]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+Visit http://localhost:8900 in your web browser to access the backend API; docs can be found at http://localhost:8900/docs.
+
+*(Again, note that the port within the container, 8000, is different than the one on the host to prevent collisions with other host services.)*
+
+### Purging Session State
+
+If you want to clear the session state, you can run the following command to stop any application containers that are running and remove the database volume:
+
+```bash
+docker compose down -v
+```
+
+This will purge any sessions or other data that ADK stores to the database.
+
+### (Optional) Running the App in Production
+
+The app includes configuration, located in `docker-compose.prod.yml`, for running the application in production mode.
+
+To use it, ensure that you've updated `DOMAIN_NAME` in your `.env` file to the domain name under which the app will be served.
+You should also ensure that you have access to map ports 80 and 443 on the machine that will be running the production app.
+
+The production configuration differs from the development configuration in a few ways:
+
+- The frontend is built and served as static files, rather than being served by a development server.
+- Volumes are disabled, and the code for each container is baked into the image. As a result, hot-reloading is disabled for all containers.
+- It uses [Caddy](https://caddyserver.com/) as a reverse proxy to serve the frontend and backend as well as to obtain an SSL cert for your chosen domain.
+  - The backend API is served from `/api/`
+  - The frontend is served from `/`
+
+To launch the production version of the app, you can run the following command:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+```
+
+This will build the production images and start the application in detached mode.
+
+To tail the container logs, you can run:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
+```
 
 - *For project members: [internal planning doc](https://olucdenver.sharepoint.com/:w:/r/sites/CenterforHealthAI939-SoftwareEngineering/Shared%20Documents/Software%20Engineering/Projects/PivLab%20-%20ADK%20Hackathon/Agent%20Development%20Kit%20Hackathon%20with%20Google%20Cloud.docx?d=w0cfff935f2754c3492489ef5b15fe2f4&csf=1&web=1&e=NRM3en)*
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Leverage the "Refine" action to implement agentic enhance your content.
 Does your research involve the use of a version controlled repository (for example, hosted on GitHub)?
 You can use Manugen AI to create a manuscript by passing the URL for the project with the "Repos" action.
 
+> ⚠️ Note: we suggest refreshing the page and starting fresh from step one below when using the below example because the "Repos" action.
+
 1. Within the frontend, paste in a GitHub URL (e.g. `https://github.com/pivlab/manugen-ai`).
 1. Highlight the GitHub URL and click the "Repos" action.
 1. Manugen AI agents will absorb information about your repository and provide a draft manuscript in return.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Enrich your content by using Manugen AI agents which query [OpenAlex](https://op
 Maintaining the integrity and trustworthiness of the scientific record is paramount, and proactively avoiding retractions is a core responsibility.
 Avoid reasons for retraction within manuscript content by using the "Retracts" action.
 
+1. If you are using local models, make sure you set `USE_GEMINI_EMBEDDINGS=0` in your `.env` file and restart the backend, so the needed files are downloaded.
+   Otherwise, a Gemini embedding model is used, and you'll need to set up an API key (`GOOGLE_API_KEY`);
+   see instructions in `.env`.
 1. Highlight any content within a draft manuscript in our front-end and click the "Retracts" action.
 1. Manugen AI will use retrieval-augmented generation (RAG) to find related reasons for retraction based on [WithdrarXiv](https://huggingface.co/datasets/darpa-scify/withdrarxiv).
 1. Content is updated to avoid reasons for retraction based on this data.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For the sake of keeping computational demands low, **the models suggested here a
 You'll need to test which model works best for your task.
 In general, we've observed that large models or those with high context size perform better (you can try larger versions of Qwen3 and Gemma3), provided you have a GPU with sufficient VRAM to maintain acceptable inference times.
 
-## Usage
+### Adjut settings (API keys, etc)
 
 **First**, clone the repository, and in a terminal, change directory to the repo folder.
 
@@ -95,7 +95,11 @@ MANUGENAI_MODEL_NAME="ollama/qwen3:8b"
 MANUGENAI_FIGURE_MODEL_NAME="ollama/gemma3:4b"
 ```
 
-**Third**, run the project:
+## Usage
+
+### Start the backend
+
+Run the following command:
 
 ```bash
 docker compose up --build

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You'll need to test which model works best for your task.
 As expected, we've observed that large models and those with high context size perform better, such as the latest models from OpenAI, Anthropic, or Google.
 Among local, open-weight models available in Ollama, we found that larger versions of Qwen3 and Gemma3 produced acceptable results, provided you have a GPU with sufficient VRAM to maintain acceptable inference times.
 
-### Adjut settings (API keys, etc)
+### Adjust settings (API keys, etc)
 
 **First**, clone the repository, and in a terminal, change directory to the repo folder.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ After opening the web interface in your browser, follow these steps to draft a m
    Click the paperclip icon in the top right to upload figures.
    Once uploaded, Manugen‑AI analyzes each image and generates a title and description, storing this information for use in drafts.
    If you've already drafted the Results section (which in the example references "Figure 1", "Figure 2", and "Figure 3") before uploading images, the system will have guessed their content.
-   To see accurate figure references, upload \[Figures 1–3 from the `frontend/public/example` folder\], then re‑draft the Results section (select its text and click *Draft*).
+   To see accurate figure references, upload Figures 1, 2 and 3 from the [`frontend/public/example`](frontend/public/example) folder, then re‑draft the Results section (select its text and click *Draft*).
    You'll now see the narrative updated to reflect each figure's actual content.
 
 <p align="left">

--- a/README.md
+++ b/README.md
@@ -127,7 +127,18 @@ It might take a few seconds to establish a connection.
 
 ### Draft a manuscript
 
-TODO: describe section draft agent
+*(Remember this is a prototype system and it is still work-in-progress, so you might find bugs)*
+
+Once you loaded the frontend in your browser, you can load the included example to draft a manuscript from scratch:
+
+1. Click on the lightbulb icon ("Try an example") on the top right to load the guidelines (a set of bullet points per section) to draft [this peer-reviewed article](https://doi.org/10.1016/j.cels.2024.08.005).
+1. To *draft* sections of the manuscript, you need to select the _entire section_ and then click on the "Draft" action (see animation below).
+   The text you selected will be replaced by the draft when it's ready.
+1. If you are not happy with the current draft, you can *edit* the current draft by adding comments in the middle of it (such as `* emphasize more on this aspect`), selecting the entire section, and clicking on "Draft" again.
+1. You can upload figures before drafting a section, or after (in this case, you'll need to *edit* that section).
+   If your text/guidance for the Results section references your figures (such as "Figure 1"), and you uploaded that figure, the agent responsible for drafting the Results section will have access to the figure's description, which will be more helpful to generate the draft.
+
+<img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
 
 ### Describe a GitHub repository
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Once you accessed the frontend in your browser, you can load the included exampl
 
 <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
 
+### Enhance existing content with revision
+
+After drafting a manuscript you may want to improve the quality of specific blocks.
+Leverage the "Refine" action to implement agentic enhance your content.
+
+1. Highlight any content within a draft manuscript in our front-end and click the "Refine" action.
+1. Manugen AI will improve the content through an agentic revision process.
+1. Content is updated and will include new revisions.
+
 ### Create a manuscript based on a version controlled repository
 
 Does your research involve the use of a version controlled repository (for example, hosted on GitHub)?

--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ After opening the web interface in your browser, follow these steps to draft a m
 
 1. **Load an example of human guidelines.**
    Click the lightbulb icon ("Try an example") in the top right.
-   This loads a set of bullet‑point notes—our "human guidelines"—that sketch out what a future scientific manuscript might include (e.g., section headings, key ideas, structural notes).
-   This built‑in example corresponds to the guidelines for [this peer‑reviewed article](https://doi.org/10.1016/j.cels.2024.08.005) and is written in Markdown.
+   This loads a set of bullet‑point notes—our "human guidance"—that sketch out what a future scientific manuscript might include (e.g., section headings, key ideas, structural notes).
+   This built‑in example corresponds to the guidance for [this peer‑reviewed article](https://doi.org/10.1016/j.cels.2024.08.005) and is written in Markdown.
    Treat this as the earliest draft of your manuscript, which will evolve over time.
 
 1. **Draft a section.**
    Select the *entire* content of the section you'd like to draft (for instance, the *Results* section, including its subsections), then click the *Draft* button.
-   Manugen‑AI will replace your selected text with a full draft generated from your guidelines.
+   Manugen‑AI will replace your selected text with a full draft generated from the guidance provided.
 
 1. **Edit an existing draft.**
    If the draft isn't quite right, add inline comments or extra bullet‑point notes—inserted anywhere within the section—to guide Manugen‑AI's revisions.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ It might take a few seconds to establish a connection.
 
 ### Draft a manuscript
 
+Manugen-AI allows a human author to quickly draft a scientific manuscript from a minimum set of research assets (such as figures or source code) and human guidance.
 After opening the web interface in your browser, follow these steps to draft a manuscript from scratch:
 
 1. **Load an example of human guidelines.**

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ docker compose up --build
 
 This will build the Docker images and start the application.
 You'll be attached to the logs of the application, which will show you live output from the various services that make up the stack.
-Pressing `Ctrl+C` will stop the application.
+You can press `Ctrl+C` if you want to stop the application.
 
 Wait until you see a message resembling the following in the logs:
 
@@ -118,70 +118,28 @@ VITE v6.3.5  ready in 1276 ms
 ➜  Network: http://172.22.0.2:5173/
 ```
 
-### Accessing the Frontend
+### Access the frontend
 
 Use a web browser to open http://localhost:8901 and to view the frontend user interface.
 It might take a few seconds to establish a connection.
 
 *(FYI: Despite the port being 5173 in the logs, the Docker Compose configuration maps it to port 8901 on the host machine.)*
 
-### Accessing the Backend API
+### Draft a manuscript
 
-While it's not necessary to use the app, you might want to access the backend API directly for testing or debugging purposes.
+TODO: describe section draft agent
 
-Wait until you see the following message in the logs:
+### Describe a GitHub repository
 
-```
-INFO:     Will watch for changes in these directories: ['/app']
-INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
-INFO:     Started reloader process [102] using WatchFiles
-INFO:     Started server process [104]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-```
+TODO: describe repo to paper agent
 
-Visit http://localhost:8900 in your web browser to access the backend API; docs can be found at http://localhost:8900/docs.
+### Add ciations
 
-*(Again, note that the port within the container, 8000, is different than the one on the host to prevent collisions with other host services.)*
+TODO: describe citations agent
 
-### Purging Session State
+### Check retractions
 
-If you want to clear the session state, you can run the following command to stop any application containers that are running and remove the database volume:
-
-```bash
-docker compose down -v
-```
-
-This will purge any sessions or other data that ADK stores to the database.
-
-### (Optional) Running the App in Production
-
-The app includes configuration, located in `docker-compose.prod.yml`, for running the application in production mode.
-
-To use it, ensure that you've updated `DOMAIN_NAME` in your `.env` file to the domain name under which the app will be served.
-You should also ensure that you have access to map ports 80 and 443 on the machine that will be running the production app.
-
-The production configuration differs from the development configuration in a few ways:
-
-- The frontend is built and served as static files, rather than being served by a development server.
-- Volumes are disabled, and the code for each container is baked into the image. As a result, hot-reloading is disabled for all containers.
-- It uses [Caddy](https://caddyserver.com/) as a reverse proxy to serve the frontend and backend as well as to obtain an SSL cert for your chosen domain.
-  - The backend API is served from `/api/`
-  - The frontend is served from `/`
-
-To launch the production version of the app, you can run the following command:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
-```
-
-This will build the production images and start the application in detached mode.
-
-To tail the container logs, you can run:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
-```
+TODO: describe repo to paper agent
 
 ## Other Resources
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,9 @@ After opening the web interface in your browser, follow these steps to draft a m
    The system will incorporate your new instructions into the updated draft.
 
 1. **Upload and integrate figures.**
-   Click the paperclip icon in the top right to upload figures.
-   Once uploaded, Manugen‑AI analyzes each image and generates a title and description, storing this information for use in drafts.
+   Once you upload a figure, Manugen‑AI analyzes the image and generates a title and description, storing this information for use in drafts.
    If you've already drafted the Results section (which in the example references "Figure 1", "Figure 2", and "Figure 3") before uploading images, the system will have guessed their content.
-   To see accurate figure references, upload Figures 1, 2 and 3 from the [`frontend/public/example`](frontend/public/example) folder, then re‑draft the Results section (select its text and click *Draft*).
+   To see accurate figure references in the text, click the paperclip icon in the top right and upload Figures 1, 2 and 3 from the [`frontend/public/example`](frontend/public/example) folder, then re‑draft the Results section (select its entire text and click *Draft*).
    You'll now see the narrative updated to reflect each figure's actual content.
 
 <p align="left">

--- a/README.md
+++ b/README.md
@@ -127,8 +127,6 @@ It might take a few seconds to establish a connection.
 
 ### Draft a manuscript
 
-*(Remember this is a prototype system and it is still work-in-progress, so you might find bugs)*
-
 After opening the web interface in your browser, follow these steps to draft a manuscript from scratch:
 
 1. **Load an example of human guidelines.**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ ollama pull gemma3:4b
 
 For the sake of keeping computational demands low, **the models suggested here are small and may not yield the best results.**
 You'll need to test which model works best for your task.
-In general, we've observed that large models or those with high context size perform better (you can try larger versions of Qwen3 and Gemma3), provided you have a GPU with sufficient VRAM to maintain acceptable inference times.
+As expected, we've observed that large models and those with high context size perform better, such as the latest models from OpenAI, Anthropic, or Google.
+Among local, open-weight models available in Ollama, we found that larger versions of Qwen3 and Gemma3 produced acceptable results, provided you have a GPU with sufficient VRAM to maintain acceptable inference times.
 
 ### Adjut settings (API keys, etc)
 

--- a/README.md
+++ b/README.md
@@ -149,17 +149,32 @@ Once you accessed the frontend in your browser, you can load the included exampl
 
 <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
 
-### Describe a GitHub repository
+### Create a manuscript based on a version controlled repository
 
-TODO: describe repo to paper agent
+Does your research involve the use of a version controlled repository (for example, hosted on GitHub)?
+You can use Manugen AI to create a manuscript by passing the URL for the project with the "Repos" action.
 
-### Add ciations
+1. Within the frontend, paste in a GitHub URL (e.g. `https://github.com/pivlab/manugen-ai`).
+2. Highlight the GitHub URL and click the "Repos" action.
+3. Manugen AI agents will absorb information about your repository and provide a draft manuscript in return.
 
-TODO: describe citations agent
+### Enrich manuscript content with related citations
 
-### Check retractions
+No manuscript is complete without citations from related work.
+Enrich your content by using Manugen AI agents which query [OpenAlex](https://openalex.org/) through the "Cites" action.
 
-TODO: describe repo to paper agent
+1. Highlight any content within a draft manuscript in our front-end and click the "Cites" action.
+2. Manugen AI will summarize the content and leverage OpenAlex to query for related citations.
+3. Content is updated to include information with related citation.
+
+### Avoid reasons for retraction
+
+Maintaining the integrity and trustworthiness of the scientific record is paramount, and proactively avoiding retractions is a core responsibility.
+Avoid reasons for retraction within manuscript content by using the "Retracts" action.
+
+1. Highlight any content within a draft manuscript in our front-end and click the "Retracts" action.
+2. Manugen AI will use retrieval-augmented generation (RAG) to find related reasons for retraction based on [WithdrarXiv](https://huggingface.co/datasets/darpa-scify/withdrarxiv).
+3. Content is updated to avoid reasons for retraction based on this data.
 
 ## Other Resources
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ It might take a few seconds to establish a connection.
 
 *(FYI: Despite the port being 5173 in the logs, the Docker Compose configuration maps it to port 8901 on the host machine.)*
 
+You'll see two text fields: one on the left for entering manuscript content in Markdown, and one on the right displaying a live preview.
+
 ### Draft a manuscript
 
 Manugen-AI allows a human author to quickly draft a scientific manuscript from a minimum set of research assets (such as figures or source code) and human guidance.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Our experienced team of engineers intends to turn this proof-of-concept into a f
 ## Get started
 
 - 🎥 Watch our demo [YouTube video](https://youtu.be/WkfA-7lXE5w?si=7P_1BMonfFpm_2YE)
-- 🔖 Read our [blog post](https://pivlab.org/2025/06/23/Google-ADK-Hackathon.html)
+- 🔖 Read our [story on
+  Medium](https://medium.com/@miltondp/manugen-ai-automatic-scientific-article-drafting-from-assets-and-guidance-47198ab0f244)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,8 @@ Leverage the "Refine" action to implement agentic enhance your content.
 Does your research involve the use of a version controlled repository (for example, hosted on GitHub)?
 You can use Manugen AI to create a manuscript by passing the URL for the project with the "Repos" action.
 
-> ⚠️ Note: we suggest refreshing the page and starting fresh from step one below when using the below example because the "Repos" action.
-
-1. Within the frontend, paste in a GitHub URL (e.g. `https://github.com/pivlab/manugen-ai`).
+1. Within the frontend, refresh your browser so you start with an empty session.
+1. On the left panel, paste in a GitHub URL (e.g. `https://github.com/pivlab/manugen-ai`).
 1. Highlight the GitHub URL and click the "Repos" action.
 1. Manugen AI agents will absorb information about your repository and provide a draft manuscript in return.
 

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Does your research involve the use of a version controlled repository (for examp
 You can use Manugen AI to create a manuscript by passing the URL for the project with the "Repos" action.
 
 1. Within the frontend, paste in a GitHub URL (e.g. `https://github.com/pivlab/manugen-ai`).
-2. Highlight the GitHub URL and click the "Repos" action.
-3. Manugen AI agents will absorb information about your repository and provide a draft manuscript in return.
+1. Highlight the GitHub URL and click the "Repos" action.
+1. Manugen AI agents will absorb information about your repository and provide a draft manuscript in return.
 
 ### Enrich manuscript content with related citations
 
@@ -164,8 +164,8 @@ No manuscript is complete without citations from related work.
 Enrich your content by using Manugen AI agents which query [OpenAlex](https://openalex.org/) through the "Cites" action.
 
 1. Highlight any content within a draft manuscript in our front-end and click the "Cites" action.
-2. Manugen AI will summarize the content and leverage OpenAlex to query for related citations.
-3. Content is updated to include information with related citation.
+1. Manugen AI will summarize the content and leverage OpenAlex to query for related citations.
+1. Content is updated to include information with related citation.
 
 ### Avoid reasons for retraction
 
@@ -173,8 +173,8 @@ Maintaining the integrity and trustworthiness of the scientific record is paramo
 Avoid reasons for retraction within manuscript content by using the "Retracts" action.
 
 1. Highlight any content within a draft manuscript in our front-end and click the "Retracts" action.
-2. Manugen AI will use retrieval-augmented generation (RAG) to find related reasons for retraction based on [WithdrarXiv](https://huggingface.co/datasets/darpa-scify/withdrarxiv).
-3. Content is updated to avoid reasons for retraction based on this data.
+1. Manugen AI will use retrieval-augmented generation (RAG) to find related reasons for retraction based on [WithdrarXiv](https://huggingface.co/datasets/darpa-scify/withdrarxiv).
+1. Content is updated to avoid reasons for retraction based on this data.
 
 ## Other Resources
 

--- a/README.md
+++ b/README.md
@@ -131,15 +131,21 @@ It might take a few seconds to establish a connection.
 
 Once you accessed the frontend in your browser, you can load the included example to draft a manuscript from scratch:
 
-1. Click on the lightbulb icon ("Try an example") on the top right to load the guidelines (a set of bullet points per section) to draft [this peer-reviewed article](https://doi.org/10.1016/j.cels.2024.08.005).
-   You'll see that the example contains a few bullet points per section.
-   These are the brief guidelines provided by human authors.
-1. To *draft* sections of the manuscript, you need to select the _entire section_ content and then click on the "Draft" action (see animation below).
+1. **Load an example of human guidelines:** click on the lightbulb icon ("Try an example") on the top right to load an example.
+   This example represents some ideas that a human author might quickly sketch when thinking in a future scientific manuscript.
+   These ideas might be a set of bullet points per section with early notes on how you are thinking about the structure, content, etc.
+   We call this the "human guidelines" for Manugen-AI.
+   The example corresponds to the guidelines for [this peer-reviewed article](https://doi.org/10.1016/j.cels.2024.08.005).
+   You'll see the example is written in Markdown, with some ideas for the different sections (abstract, results, etc).
+   This is what the most early version of your manuscript might look like, and will surely evolve with time.
+1. **Draft a section:** to *draft* sections of the manuscript, you need to select the _entire section_ content and then click on the "Draft" action (see animation below).
+   You can try with the entire Results section (which includes two subsections).
    When ready, the text you selected will be replaced by the draft.
-1. If you are not happy with the current draft, you can *edit* the current draft by adding comments in the middle of it (such as bullet points before a paragraph or notes in the middle of the text), selecting the entire section, and clicking on "Draft" again.
-1. You can upload figures before drafting a section by clicking on the paperclip icon on the top right corner.
-   If your text/guidance for the Results section references your figures (such as "Figure 1"), and you uploaded that figure, the agent responsible for drafting the Results section will have access to the figure's description, which will be more helpful to generate the draft.
-   If you upload a figure after drafting the Results section, you can *edit* that section to incorporate the figure.
+1. **Edit an existing draft:** if you are not happy with the current draft, you can *edit* it by adding comments/instructions in the middle (such as bullet points before a paragraph or notes in the middle of the text with instructions for Manugen-AI), selecting the entire section, and clicking on "Draft" again.
+1. **Upload figures:** you can upload figures by clicking on the paperclip icon on the top right corner.
+   Once you upload a figure, Manugen-AI will interpret it by generating a title and a description that will be added to the internal state of the system, and used by the Results Agent when drafting this section.
+   When you drafted the Results section in the steps above (which had references to "Figure 1", "Figure 2" and "Figure 3"), the system didn't have any figures added yet, so the agent did its best with the content you provided in the bullet points.
+   Now, try to upload [Figures 1, 2 and 3 from this folder](frontend/public/example), and then *edit* the Results section (just select its text and click on the "Draft" action), and you'll see how its text now correctly references the actual content of the figures.
 
 <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Project Logo" width="100%" />
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ After opening the web interface in your browser, follow these steps to draft a m
    To see accurate figure references in the text, click the paperclip icon in the top right and upload Figures 1, 2 and 3 from the [`frontend/public/example`](frontend/public/example) folder, then re‑draft the Results section (select its entire text and click *Draft*).
    You'll now see the narrative updated to reflect each figure's actual content.
 
-<p align="left">
-  <img src="https://miro.medium.com/v2/resize:fit:720/format:webp/1*GXmqk39rXlR9bbiLP5FIsw.gif" alt="Drafting a manuscript section" width="90%" />
-</p>
+1. **Draft the Methods section from source code files.**
+   The Methods Agent, responsible for drafting this section, can use tools to download and understand programming source code.
+   The guidance for the Methods section in the example contains a URL link to a Python file in a GitHub repository.
+   Select the entire text of the Methods section and click on the *Draft* action.
 
 ### Enhance existing content with revision
 


### PR DESCRIPTION
This PR improves the `README.md` file to make it more clear for a user who only wants to quickly test the system. It adds instructions on how to test each agent.