### PR TITLE
Address missing exe `xdg-open` with frontend image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,10 @@ FROM oven/bun:latest
 
 WORKDIR /app
 
+# address issue with error within logs when running:
+# `Error: Executable not found in $PATH: "xdg-open"`
+RUN apt update && apt install xdg-utils --fix-missing -y
+
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
When running `docker compose up --build` the frontend appears to sometimes emit an error: `Error: Executable not found in $PATH: "xdg-open"`. This appears to be related to a missing dependency within the container. This PR addresses the missing dependency by adding it.