### PR TITLE
Use frozen package to avoid dependency surprises

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -39,7 +39,7 @@ repos:
     -   id: yamllint
         exclude: pre-commit-config.yaml
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.4"
+    rev: "v0.13.0"
     hooks:
     -   id: ruff-format
     -   id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     -   id: yamllint
         exclude: pre-commit-config.yaml
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.3"
+    rev: "v0.12.4"
     hooks:
     -   id: ruff-format
     -   id: ruff-check

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=manugen-ai/uv.lock,target=uv.lock \
     --mount=type=bind,source=manugen-ai/pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+    uv sync --frozen --no-install-project
 
 # Copy the project into the image
 ADD ./manugen-ai/ /app

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -18,4 +18,4 @@ ADD ./manugen-ai/ /app
 
 # Sync the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked
+    uv sync --frozen


### PR DESCRIPTION
This PR updates the `manugen-ai` package to use the `--frozen` flag which will use the `uv.lock` file to ensure we have reproducible builds of the package. My understanding from the [`uv` docs](https://docs.astral.sh/uv/concepts/projects/sync/) on this matter is that `--locked` will check that the `uv.lock` file is up to date (it's kinda confusing). 